### PR TITLE
Save Puppet 3 compatible and systemd support on Debian 8

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,7 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   }
 
-  if ($version[0] == '7' ){
+  if (versioncmp($jira::version, '7.0.0') >= 0 ){
     file { "${jira::webappdir}/conf/server.xml":
       content => template('jira/server7.xml.erb'),
       mode    => '0600',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,14 +42,14 @@ class jira::install {
 
   # https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.0-jira-7.0.0-x64.bin
 
-  if ($jira::version[0] == '7' ){
+  if (split($jira::version, '.')[0] == '7' ){
     $file = "atlassian-jira-software-7.0.0-${jira::product}-${jira::version}${jira::format}"
   }else {
     $file = "atlassian-${jira::product}-${jira::version}${jira::format}"
   }
   if $jira::staging_or_deploy == 'staging' {
 
-    class{'staging':}
+    require staging
 
     if ! defined(File[$jira::webappdir]) {
       file { $jira::webappdir:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,14 +42,15 @@ class jira::install {
 
   # https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.0-jira-7.0.0-x64.bin
 
-  if (split($jira::version, '.')[0] == '7' ){
+  $version = split($jira::version, '.')
+  if ($version[0] == '7' ){
     $file = "atlassian-jira-software-7.0.0-${jira::product}-${jira::version}${jira::format}"
   }else {
     $file = "atlassian-${jira::product}-${jira::version}${jira::format}"
   }
   if $jira::staging_or_deploy == 'staging' {
 
-    require staging
+    class{'staging':}
 
     if ! defined(File[$jira::webappdir]) {
       file { $jira::webappdir:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,9 +41,7 @@ class jira::install {
   }
 
   # https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.0-jira-7.0.0-x64.bin
-
-  $version = split($jira::version, '.')
-  if ($version[0] == '7' ){
+  if (versioncmp($jira::version, '7.0.0') >= 0 ){
     $file = "atlassian-jira-software-7.0.0-${jira::product}-${jira::version}${jira::format}"
   }else {
     $file = "atlassian-${jira::product}-${jira::version}${jira::format}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class jira::params {
     } /Debian/: {
       if $::operatingsystemmajrelease == '8' {
         $json_packages           = 'ruby-json'
-        $service_file_location   = '/etc/systemd/user/jira.service'
+        $service_file_location   = '/lib/systemd/system/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
         $service_systemd         = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,11 +13,13 @@ class jira::params {
         $service_file_location   = '/usr/lib/systemd/system/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+        $service_systemd         = true
       } elsif $::operatingsystemmajrelease == '6' or $::operatingsystem == 'Amazon'{
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+        $service_systemd         = false
       } else {
         fail("\"${module_name}\" provides no service parameters
             for \"${::osfamily}\" - \"${::operatingsystemmajrelease}\"")
@@ -28,11 +30,13 @@ class jira::params {
         $service_file_location   = '/etc/systemd/user/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+        $service_systemd         = true
       } else {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/jira'
+        $service_systemd         = false
       }
     } default: {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class jira::params {
     } /Debian/: {
       if $::operatingsystemmajrelease == '8' {
         $json_packages           = 'ruby-json'
-        $service_file_location   = '/usr/lib/systemd/system/jira.service'
+        $service_file_location   = '/etc/systemd/user/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
       } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,10 +23,17 @@ class jira::params {
             for \"${::osfamily}\" - \"${::operatingsystemmajrelease}\"")
       }
     } /Debian/: {
+      if $::operatingsystemmajrelease == '8' {
+        $json_packages           = 'ruby-json'
+        $service_file_location   = '/usr/lib/systemd/system/jira.service'
+        $service_file_template   = 'jira/jira.service.erb'
+        $service_lockfile        = '/var/lock/subsys/jira'
+      } else {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/jira'
+      }
     } default: {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,7 @@ class jira::service(
   $service_file_location = $jira::params::service_file_location,
   $service_file_template = $jira::params::service_file_template,
   $service_lockfile      = $jira::params::service_lockfile,
+  $service_systemd       = $jira::params::service_systemd,
 
 ) inherits jira::params {
   
@@ -38,9 +39,7 @@ class jira::service(
     validate_string($service_ensure)
     validate_bool($service_enable)
 
-    # TODO: Move systemd atribute to config variable
-    if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7')
-      or ($::osfamily == 'Debian' and $::operatingsystemmajrelease == '8') {
+    if $service_systemd {
       exec { 'refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,7 +38,9 @@ class jira::service(
     validate_string($service_ensure)
     validate_bool($service_enable)
 
-    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {
+    # TODO: Move systemd atribute to config variable
+    if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7')
+      or ($::osfamily == 'Debian' and $::operatingsystemmajrelease == '8') {
       exec { 'refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,


### PR DESCRIPTION
Hi! I'm try to install Jira 7 with my Puppet 3 (3.8.1 on master and 3.7.2 on agent) and get an error: 
```
jira::version is not a hash or array when accessing it with 0 at /etc/puppet/environments/jira7/modules/jira/manifests/install.pp:45 on node jira7-app.
```

How do you feel about use versioncmp function instead first character comparing?