### PR TITLE
Fix deployment files to unblock spec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class jira (
   # Jira Settings
   $version      = '6.4.1',
   $product      = 'jira',
-  $format       = '.tar.gz',
+  $format       = 'tar.gz',
   $installdir   = '/opt/jira',
   $homedir      = '/home/jira',
   $user         = 'jira',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,9 +44,9 @@ class jira::install {
   # https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.0.3.tar.gz
 
   if (versioncmp($jira::version, '7.0.0') < 0  ){
-    $file = "atlassian-jira-core-${jira::product}-${jira::version}${jira::format}"
+    $file = "atlassian-${jira::product}-${jira::version}.${jira::format}"
   }else {
-    $file = "atlassian-jira-core-${jira::version}${jira::format}"
+    $file = "atlassian-jira-core-${jira::version}.${jira::format}"
   }
   if $jira::staging_or_deploy == 'staging' {
 


### PR DESCRIPTION
The format parameter needs to not have a leading . or all of the spec
tests need to be fixed to pass it in. As removing it is the simpler
option this does that.

Secondly, the calculated file names for the deploy need to have the file
extension . added. Also, the calculated file name for pre-7.0.0 had been
destroyed, this puts it back to what it should be.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>